### PR TITLE
v0.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,9 @@ jobs:
         uses: taiki-e/install-action@3fa6878dc4ae603f73960271565a082bf196ab96  # v2.77.2
         with:
           tool: cargo-auditable
+      - name: Ensure cargo-auditable (Alpine cache fallback)
+        if: matrix.container == 'rust:alpine'
+        run: command -v cargo-auditable || cargo install cargo-auditable --locked
       - name: Cargo Build Release (with auditable dep-tree embedded)
         shell: sh
         # `cargo auditable build` is a thin wrapper: it builds via cargo


### PR DESCRIPTION
Release v0.6.1

## Changes

- **perf**: iai-callgrind instruction-count benchmarks
- **docs**: benchmark reproduction guide and target-cpu notes
- **feat**: color transform and downgrade pipeline
- **feat**: classifier, filter, and preset enhancements
- **feat**: unicode normalization and parser improvements
- **feat**: CLI preset and integration test updates
- **ci**: local CI parity, nextest config, and contributor docs
- **ci**: cargo-auditable cache fallback for Alpine build

## Testing

- `mise run ci` passes locally
- `mise run release:dry-run` validates crates.io publish
- `cargo test --all-features` passes (565 tests)